### PR TITLE
Page action

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,8 +1,17 @@
 /**
  * Execute tabs.js in context of current tab.
  */
-chrome.browserAction.onClicked.addListener(function(tab) {
+chrome.pageAction.onClicked.addListener(function(tab) {
   chrome.tabs.executeScript(null, { file: "js/tabs.js" });
+});
+
+/**
+ * Show page action on tabs which contains "feedly.com".
+ */
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+  if (tab.url.indexOf("feedly.com") > -1) {
+    chrome.pageAction.show(tabId);
+  }
 });
 
 /**

--- a/manifest.json
+++ b/manifest.json
@@ -7,15 +7,16 @@
     "48":   "images/icon48.png",
     "128":  "images/icon128.png"
   },
-  "version": "0.1.0",
+  "version": "0.2.0",
   "permissions": [
     "tabs", "http://*.feedly.com/home*"
   ],
-  "browser_action": {
+  "page_action": {
     "default_icon": {
       "19": "images/icon19.png",
       "38": "images/icon38.png"
-    }
+    },
+    "default_title": "Open Feedly articles in new tabs"
   },
   "background": {
     "scripts": ["js/background.js"]


### PR DESCRIPTION
Following a tip from https://developer.chrome.com/extensions/browserAction.html

```
Don't use browser actions for features that make sense for only a few pages. Use page actions instead.
```

Using pageAction for Feedly tabs might be the right solution.
- [x] Make a screenshot
- [x] Make a screencast
- [x] Update Webstore
